### PR TITLE
Add find functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ import (
 	"fmt"
 	"github.com/brehv/r"
 )
+
 var R = r.R
+var F = r.F
+
 type Person struct {
 	Name    string
 	Parents Parents
@@ -45,8 +48,11 @@ func main() {
 	fmt.Println(p) //{Milhouse {Cherry Dennis}}
 	updated := R(p, "Parents.Dad", "Larry")
 	fmt.Println(updated) //{Milhouse {Cherry Larry}}
+
+	value := F(p, "Parents.Mom")
+	fmt.Println(value) // Cherry
 }
 
 ```
 
-Again, feel free to look in `r_test.go` to see more examples
+Again, feel free to look in `r_test.go` or `f_test.go` to see more examples

--- a/f.go
+++ b/f.go
@@ -8,39 +8,85 @@ import (
 // F is a function that allows you to find a value in a struct n levels deep
 // returning the value
 // See f_test.go for examples
+
 func F(subj interface{}, fName string) interface{} {
 	if isNil(subj) {
 		return nil
 	}
 
 	s := strings.Split(fName, ".")
+
+	switch reflect.TypeOf(subj).Kind() {
+	case reflect.Struct, reflect.Ptr:
+		return fStruct(subj, s)
+	case reflect.Map:
+		return fMap(subj, s)
+	default:
+		return nil
+	}
+}
+
+func fStruct(subj interface{}, s []string) interface{} {
+	if isNil(subj) {
+		return nil
+	}
+
 	var current reflect.Value
 
 	switch reflect.TypeOf(subj).Kind() {
 	case reflect.Ptr:
 		current = reflect.Indirect(reflect.ValueOf(subj))
-
 	default:
 		original := reflect.ValueOf(subj)
 		current = reflect.New(original.Type()).Elem()
 		for j := 0; j < original.NumField(); j++ {
 			f := original.Field(j)
 			n := original.Type().Field(j).Name
+			if !current.FieldByName(n).CanSet() {
+				return nil
+			}
 			current.FieldByName(n).Set(f)
 		}
 	}
-
 	if len(s) == 1 {
-		field := current.FieldByName(fName)
+		field := current.FieldByName(s[0])
 		if field.IsValid() {
 			return field.Interface()
 		}
 	} else {
 		next := current.FieldByName(s[0])
 		updated := F(next.Interface(), strings.Join(s[1:], "."))
+		if updated == nil {
+			return nil
+		}
 		if next.IsValid() {
 			return reflect.ValueOf(updated).Interface()
 		}
 	}
 	return current.Interface()
+}
+
+func fMap(subj interface{}, s []string) interface{} {
+	if isNil(subj) {
+		return nil
+	}
+	current := reflect.ValueOf(subj)
+	if len(s) == 1 {
+		key := reflect.ValueOf(s[0])
+		field := current.MapIndex(key)
+		if field.IsValid() {
+			return field.Interface()
+		}
+	} else {
+		key := reflect.ValueOf(s[0])
+		next := current.MapIndex(key)
+		updated := F(next.Interface(), strings.Join(s[1:], "."))
+		if updated == nil {
+			return nil
+		}
+		if next.IsValid() {
+			return reflect.ValueOf(updated).Interface()
+		}
+	}
+	return nil
 }

--- a/f.go
+++ b/f.go
@@ -1,0 +1,46 @@
+package r
+
+import (
+	"reflect"
+	"strings"
+)
+
+// F is a function that allows you to find a value in a struct n levels deep
+// returning the value
+// See f_test.go for examples
+func F(subj interface{}, fName string) interface{} {
+	if isNil(subj) {
+		return nil
+	}
+
+	s := strings.Split(fName, ".")
+	var current reflect.Value
+
+	switch reflect.TypeOf(subj).Kind() {
+	case reflect.Ptr:
+		current = reflect.Indirect(reflect.ValueOf(subj))
+
+	default:
+		original := reflect.ValueOf(subj)
+		current = reflect.New(original.Type()).Elem()
+		for j := 0; j < original.NumField(); j++ {
+			f := original.Field(j)
+			n := original.Type().Field(j).Name
+			current.FieldByName(n).Set(f)
+		}
+	}
+
+	if len(s) == 1 {
+		field := current.FieldByName(fName)
+		if field.IsValid() {
+			return field.Interface()
+		}
+	} else {
+		next := current.FieldByName(s[0])
+		updated := F(next.Interface(), strings.Join(s[1:], "."))
+		if next.IsValid() {
+			return reflect.ValueOf(updated).Interface()
+		}
+	}
+	return current.Interface()
+}

--- a/f_test.go
+++ b/f_test.go
@@ -120,6 +120,14 @@ func TestF(t *testing.T) {
 			},
 			want: []string{"one", "two"},
 		},
+		{
+			name: "Slice Get Value",
+			args: args{
+				subj:  Person{Name: "Milhouse", Slice: []string{"one", "two"}},
+				fName: "Slice.1",
+			},
+			want: "two",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/f_test.go
+++ b/f_test.go
@@ -41,7 +41,7 @@ func TestF(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "Passing in pointer to empty struct will return original value",
+			name: "Passing in pointer to empty struct will return empty value",
 			args: args{
 				subj:  pPerson,
 				fName: "Name",
@@ -79,6 +79,38 @@ func TestF(t *testing.T) {
 				fName: "A.Person.StructWithMap.RegularMap",
 			},
 			want: map[string]string{"hello": "hello"},
+		},
+		{
+			name: "Maps Part Four",
+			args: args{
+				subj:  B{A: A{Person: Person{Name: "Cherry", StructWithMap: StructWithMap{RegularMap: map[string]string{"hello": "hello"}}}}},
+				fName: "A.Person.StructWithMap.RegularMap.hello",
+			},
+			want: "hello",
+		},
+		{
+			name: "Maps Part Five",
+			args: args{
+				subj:  StructWithMap{StructMap: map[string]interface{}{"oneHundred": Nested{100}}},
+				fName: "StructMap.oneHundred",
+			},
+			want: Nested{100},
+		},
+		{
+			name: "Maps Part Six - Unexported Field return nil",
+			args: args{
+				subj:  StructWithMap{StructMap: map[string]interface{}{"oneHundred": Nested{100}}},
+				fName: "StructMap.oneHundred.i",
+			},
+			want: nil,
+		},
+		{
+			name: "Maps Part Seven - Exported Field",
+			args: args{
+				subj:  StructWithMap{StructMap: map[string]interface{}{"oneHundred": NestedExported{100}}},
+				fName: "StructMap.oneHundred.I",
+			},
+			want: 100,
 		},
 		{
 			name: "Slice",

--- a/f_test.go
+++ b/f_test.go
@@ -1,0 +1,103 @@
+package r
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestF(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		subj  interface{}
+		fName string
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "Struct will return Struct",
+			args: args{
+				subj:  Person{Name: "Lar"},
+				fName: "Name",
+			},
+			want: "Lar",
+		},
+		{
+			name: "Pointer to Struct will return Struct",
+			args: args{
+				subj:  &Person{Name: "Larry"},
+				fName: "Name",
+			},
+			want: "Larry",
+		},
+		{
+			name: "Will Get Empty Field",
+			args: args{
+				subj:  Person{},
+				fName: "Name",
+			},
+			want: "",
+		},
+		{
+			name: "Passing in pointer to empty struct will return original value",
+			args: args{
+				subj:  pPerson,
+				fName: "Name",
+			},
+			want: nil,
+		},
+		{
+			name: "Two Levels Deep",
+			args: args{
+				subj:  B{A: A{Person: Person{Name: "Éire"}}},
+				fName: "A.Person.Name",
+			},
+			want: "Éire",
+		},
+		{
+			name: "Maps Part One",
+			args: args{
+				subj:  StructWithMap{StructMap: map[string]interface{}{"oneHundred": Nested{100}}},
+				fName: "StructMap",
+			},
+			want: map[string]interface{}{"oneHundred": Nested{100}},
+		},
+		{
+			name: "Maps Part Two",
+			args: args{
+				subj:  B{A: A{Person: Person{StructWithMap: StructWithMap{StructMap: map[string]interface{}{"oneHundred": Nested{100}}}}}},
+				fName: "A.Person.StructWithMap.StructMap",
+			},
+			want: map[string]interface{}{"oneHundred": Nested{100}},
+		},
+		{
+			name: "Maps Part Three",
+			args: args{
+				subj:  B{A: A{Person: Person{Name: "Cherry", StructWithMap: StructWithMap{RegularMap: map[string]string{"hello": "hello"}}}}},
+				fName: "A.Person.StructWithMap.RegularMap",
+			},
+			want: map[string]string{"hello": "hello"},
+		},
+		{
+			name: "Slice",
+			args: args{
+				subj:  Person{Name: "Milhouse", Slice: []string{"one", "two"}},
+				fName: "Slice",
+			},
+			want: []string{"one", "two"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := F(tt.args.subj, tt.args.fName); !reflect.DeepEqual(got, tt.want) {
+				typeofgot := reflect.TypeOf(got)
+				typeofwant := reflect.TypeOf(tt.want)
+				t.Log(typeofgot, typeofwant)
+				t.Errorf("F() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/r_test.go
+++ b/r_test.go
@@ -14,6 +14,11 @@ type StructWithMap struct {
 	RegularMap map[string]string
 	StructMap  map[string]interface{}
 }
+
+type StructWithSlice struct {
+	Slice []string
+}
+
 type A struct {
 	Person Person
 }

--- a/r_test.go
+++ b/r_test.go
@@ -24,6 +24,10 @@ type Nested struct {
 	i int
 }
 
+type NestedExported struct {
+	I int
+}
+
 var pPerson *Person
 
 func TestR(t *testing.T) {


### PR DESCRIPTION
Similar to `R()`, `F()` provides the ability to access a field in an interface{}.

Pretty much the same code, but rather than setting a value it simply returns it. I could move common code into another function. But i quite liked the simplicity of having them both non-reliant on each other or common code.